### PR TITLE
Use postwalk instead of prewalk in bind-fields.

### DIFF
--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -1,6 +1,6 @@
 (ns reagent-forms.core
   (:require
-   [clojure.walk :refer [prewalk]]
+   [clojure.walk :refer [postwalk]]
    [clojure.string :refer [split]]
    [goog.string :as gstring]
    [goog.string.format]
@@ -285,7 +285,7 @@
    events - any events that should be triggered when the document state changes"
   [form doc & events]
   (let [opts {:doc doc :get #(get-in @doc (id->path %)) :save! (mk-save-fn doc events)}
-        form (prewalk
+        form (postwalk
                (fn [node]
                  (if (field? node)
                    (let [field (init-field node opts)]


### PR DESCRIPTION
This enables forms that can be toggled, e.g.
[:div {:field :alert :id :something :event exists?}
 [:input {:field :text :id :something-else}]]

This isn't possible if we use prewalk, since the alert field is processed before the input, causing the input to not be rendered.

AFAICT, this doesn't really have any negative consequences.
