### PR TITLE
Properly handle external updates to atoms.

### DIFF
--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -291,12 +291,12 @@
    doc - the document that the fields will be bound to
    events - any events that should be triggered when the document state changes"
   [form doc & events]
-  (let [opts {:doc doc :get #(get-in @doc (id->path %)) :save! (mk-save-fn doc events)}
-        form (postwalk
-               (fn [node]
-                 (if (field? node)
-                   (let [field (init-field node opts)]
-                     (if (fn? field) [field] field))
-                   node))
-               form)]
-    (fn [] form)))
+  (let [opts {:doc doc
+              :get #(get-in @doc (id->path %))
+              :save! (mk-save-fn doc events)}
+        transform (fn [node]
+                    (if (field? node)
+                      (let [field (init-field node opts)]
+                        (if (fn? field) [field] field))
+                      node))]
+    (postwalk transform form)))


### PR DESCRIPTION
Currently, some forms do not properly update when the underlying atom changes.

For instance, in the following example (which has two selects operating on the same atom), changing one select will not update the other.

``` clojure
(let [doc (atom {})
        form [:select.form-control {:field :list :id :derp}
              [:option {:key :foo} "foo"]
              [:option {:key :bar} "bar"]]]
    [:div
     [bind-fields form doc]
     [bind-fields form doc]])
```

Obviously, this behavior is not very reactive, and can cause headaches (it seems to be the problem in #19).

This commit fixes this behavior by making bind-fields return a form directly (rather than returning a function which returns a pre-computed form).

While this will incur a slight performance penalty on updates relative to the alternative, it shouldn't be noticeable.
