### PR TITLE
Stylesheet fixes for the datepicker

### DIFF
--- a/resources/reagent-forms.css
+++ b/resources/reagent-forms.css
@@ -20,7 +20,10 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  */
-.datepicker {
+.datepicker-wrapper {
+  position: relative;
+}
+.datepicker.dp-inline {
   top: 0;
   left: 0;
   padding: 4px;
@@ -28,6 +31,24 @@
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   border-radius: 4px;
+}
+.datepicker.dp-dropdown {
+  position: absolute;
+  z-index: 1000;
+  top: 100%;
+  left: 0;
+  padding: 4px;
+  margin-top: 1px;
+  min-width: 160px;
+  float: left;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+  background-color: white;
+  border: 1px solid #ccc; // IE8 fallback
+  border: 1px solid rgba(0,0,0,.15);
+  background-clip: padding-box;
+  
 }
 .datepicker:before {
   content: '';

--- a/resources/reagent-forms.css
+++ b/resources/reagent-forms.css
@@ -142,7 +142,7 @@
   background-color: #003399 \9;
 }
 
-.datepicker td, .datepicker td span {
+.datepicker td span {
   display: block;
   float: left;
   margin: 2px;
@@ -151,6 +151,7 @@
   -moz-border-radius: 4px;
   border-radius: 4px;
 }
+
 .datepicker td:hover, td span:hover {
   background: #eeeeee;
 }

--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -117,7 +117,7 @@
         today (js/Date.)
         expanded? (atom false)]
     (render-element attrs doc
-      [:div
+      [:div.datepicker-wrapper
        [:div.input-group.date
          [:input.form-control
           {:read-only true
@@ -127,7 +127,7 @@
          [:span.input-group-addon
           {:on-click #(swap! expanded? not)}
           [:i.glyphicon.glyphicon-calendar]]]
-       [datepicker (.getFullYear today) (.getMonth today) (.getDate today) expanded? auto-close? #(get id) #(save! id %)]])))
+       [datepicker (.getFullYear today) (.getMonth today) (.getDate today) expanded? auto-close? #(get id) #(save! id %) inline]])))
 
 
 (defmethod init-field :checkbox

--- a/src/reagent_forms/datepicker.cljs
+++ b/src/reagent_forms/datepicker.cljs
@@ -201,12 +201,12 @@
    (into [:tbody]
          (gen-days date get save! expanded? auto-close?))])
 
-(defn datepicker [year month day expanded? auto-close? get save!]
+(defn datepicker [year month day expanded? auto-close? get save! inline]
 
   (let [date (atom [year month day])
         view-selector (atom :day)]
     (fn []
-      [:div {:class (str "datepicker"(when-not @expanded? " dropdown-menu"))}
+      [:div {:class (str "datepicker" (when-not @expanded? " dropdown-menu") (if inline " dp-inline" " dp-dropdown"))}
        (condp = @view-selector
          :day   [day-picker date get save! view-selector expanded? auto-close?]
          :month [month-picker date save! view-selector]


### PR DESCRIPTION
The datepicker was broken, compressing days to a single column and not displaying the popover correctly. This PR should fix that.