### PR TITLE
Making id->path retain the namespace of type keyword.

### DIFF
--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -15,7 +15,8 @@
 (def ^:private id->path
   (memoize
     (fn [id]
-      (map keyword (-> id name (split  #"\."))))))
+      (let [segments (split (subs (str id) 1 ) #"\.")]
+        (map keyword segments)))))
 
 (defn set-doc-value [doc id value events]
   (let [path (id->path id)]


### PR DESCRIPTION
We are using namespaced keywords to keep unified attribute names from datomic through to our clients, and the id->path function was accidentally dropping the namespace.  This fixes it.

Thanks for the great library!  We had a half baked version of the same type of thing, and it's been really nice using reagent-forms so far.