### PR TITLE
changed documentation to provide examples using new css class params

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The input fields can have an optional `:fmt` attribute that can provide a format
 ```
 #### :typeahead
 
-The typeahead field uses a `:data-source` key bound to a function that takes the current input and returns a list of matching results:
+The typeahead field uses a `:data-source` key bound to a function that takes the current input and returns a list of matching results. The control uses an input element to handle user input and renders the list of choices as <ul> unordered list element containing <li> list item elements. Users may specify the css classes used to render each of these elements using the keys :input-class, :list-class and :item-class. Users may additionally specify a css class to handle highlighting of the current selection with the :highlight-class key. Reference css classes are included in the resources/public/css/reagent-forms.css file. 
 
 ```clojure
 (defn friend-source [text]
@@ -37,8 +37,11 @@ The typeahead field uses a `:data-source` key bound to a function that takes the
     #(-> % (.toLowerCase %) (.indexOf text) (> -1))
     ["Alice" "Alan" "Bob" "Beth" "Jim" "Jane" "Kim" "Rob" "Zoe"]))
 
-[:div {:field :typeahead :id :ta :data-source friend-source}]
+[:div {:field :typeahead :id :ta :data-source friend-source :input-class "form-control" :list-class "typeahead-list" :item-class "typeahead-item" :highlight-class "highlighted}]
 ```
+
+The typeahead field supports both mouse and keyboard selection. 
+
 
 #### :checkbox
 

--- a/resources/reagent-forms.css
+++ b/resources/reagent-forms.css
@@ -1,4 +1,5 @@
-.typeahead {
+
+.typeahead-list {
     list-style-type: none;
     padding: 5px;
     margin-top: 3px;
@@ -9,8 +10,20 @@
     background-color: white;
     overflow-y: scroll;
     max-height: 300px;
-    width: 200px}
+    width: 445px}
 
+
+.typeahead-item {
+  padding: 3px;
+}
+
+li.highlighted
+{
+  padding: 3px;
+  border: 1px solid grey;
+  background-color: grey;
+  color: white;
+}
 
 /*!
  * Datepicker for Bootstrap

--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -188,7 +188,7 @@
        body)))
 
 (defmethod init-field :typeahead
-  [[type {:keys [id data-source input-class] :as attrs}] {:keys [doc get save!]}]
+  [[type {:keys [id data-source input-class list-class item-class highlight-class] :as attrs}] {:keys [doc get save!]}]
   (let [typeahead-hidden? (atom true)
         mouse-on-list? (atom false)
         selected-index (atom 0)
@@ -207,24 +207,29 @@
                                               (reset! selected-index 0))
                               :on-key-down #(do 
                                               (case (.-which %)
-                                                38 (if-not (= @selected-index 0)(reset! selected-index (- @selected-index 1)))
+                                                38 (if-not 
+                                                       (= @selected-index 0)
+                                                     (reset! selected-index (- @selected-index 1)))
                                                 40 (if-not 
                                                        (= @selected-index (- (count @selections) 1)) 
                                                      (reset! selected-index (+ @selected-index 1)))
                                                 13 (do (save! id (nth @selections @selected-index))
                                                        (reset! typeahead-hidden? true))
+                                                27 (do (reset! typeahead-hidden? true)
+                                                       (reset! selected-index 0))
                                                 "default"))}]
                      (when-let [value (get id)]
                        (reset! selections (data-source (.toLowerCase value)))
-                       [:ul.typeahead {:hidden         (or (empty? @selections) @typeahead-hidden?)
-                                       :on-mouse-enter #(reset! mouse-on-list? true)
-                                       :on-mouse-leave #(reset! mouse-on-list? false)}
+                       [:ul {:hidden (or (empty? @selections) @typeahead-hidden?)
+                             :class list-class
+                             :on-mouse-enter #(reset! mouse-on-list? true)
+                             :on-mouse-leave #(reset! mouse-on-list? false)}
                         (doall  
                          (map-indexed 
                           (fn [index result] 
                             [:li {:tab-index     index 
                                   :key           index
-                                  :class         (if (= @selected-index index) "highlighted")
+                                  :class         (if (= @selected-index index) highlight-class item-class)
                                   :on-mouse-over #(do
                                                     (reset! selected-index (js/parseInt (.getAttribute (.-target %) "tabIndex"))))
                                   :on-click      #(do


### PR DESCRIPTION
changed reagent-forms.css to include example classes
changed typeahead to include support for user definition of css class
for input, ul, li, highlight
changed typeahead to include esc key support