### PR TITLE
update example reagent-forms dependency to 0.5.1

### DIFF
--- a/forms-example/project.clj
+++ b/forms-example/project.clj
@@ -4,7 +4,7 @@
 
   :dependencies
   [[org.clojure/clojure "1.6.0"]
-   [reagent-forms "0.3.9"]
+   [reagent-forms "0.5.1"]
    [json-html "0.2.8"]
    [org.clojure/clojurescript "0.0-2322"]
    [selmer "0.7.7"]


### PR DESCRIPTION
Version 0.3.9 doesn't include 25190f8ca3ad98b85336c8d2a49960ca5b5fbaab, which leads to the compiled example failing with the same error as in #56.