### PR TITLE
Add validation class attribute to container field

### DIFF
--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -101,8 +101,13 @@
         :input-field field))))
 
 (defmethod init-field :container
-  [[_ attrs :as component] {:keys [doc]}]
-  (render-element attrs doc component))
+  [[type {:keys [valid?] :as attrs} & body] {:keys [doc]}]
+  (render-element attrs doc
+    (into [type
+           (if-let [valid-class (when valid? (valid? (deref doc)))]
+             (update-in attrs [:class] #(if (not (empty? %)) (str % " " valid-class) valid-class))
+             attrs)]
+          body)))
 
 (defmethod init-field :input-field
   [[_ {:keys [field] :as attrs} :as component] {:keys [doc] :as opts}]


### PR DESCRIPTION
I made this addition as I couldn't see another way to get bootstrap's [form validation state](http://getbootstrap.com/css/#forms-control-validation) styles working.

The implementation is based on `event` in `alert`, but with semantics like `visible?`. The `valid?` attribute should be a decision function that takes the document atom and returns, for each validation state of the container's children, the name of a class corresponding to that state. The children can then inherit the styles of these classes. For example:

```clojure
[:form.form-horizontal
 [:div.form-group {:field  :container
                   :valid? #(case (:test-input %)
                                  "yes" "has-success"
                                  "no" "has-error"
                                  "maybe" "has-warning"
                                  nil)}
  [:label.control-label.col-sm-2 {:for :test-input} "yes or no?"]
  [:div.col-sm-9 [:input.form-control {:field :text :id :test-input}]]]]
```