### PR TITLE
Typeahead usability improvements

### DIFF
--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -195,7 +195,11 @@
        body)))
 
 (defmethod init-field :typeahead
-  [[type {:keys [id data-source input-class list-class item-class highlight-class result-fn clear-on-focus?] :as attrs :or {result-fn identity clear-on-focus? true}}] {:keys [doc get save!]}]
+  [[type {:keys [id data-source input-class list-class item-class highlight-class result-fn choice-fn clear-on-focus?]
+          :as attrs
+          :or {result-fn identity
+               choice-fn identity
+               clear-on-focus? true}}] {:keys [doc get save!]}]
   (let [typeahead-hidden? (atom true)
         mouse-on-list? (atom false)
         selected-index (atom 0)
@@ -224,8 +228,11 @@
                                                      (.preventDefault %)
                                                      (if-not (= @selected-index (- (count @selections) 1))
                                                        (reset! selected-index (+ @selected-index 1))))
-                                                13 (do (save! id (nth @selections @selected-index))
-                                                       (reset! typeahead-hidden? true))
+                                                13 (do
+                                                     (let [choice (nth @selections @selected-index)]
+                                                       (save! id choice)
+                                                       (choice-fn choice))
+                                                     (reset! typeahead-hidden? true))
                                                 27 (do (reset! typeahead-hidden? true)
                                                        (reset! selected-index 0))
                                                 "default"))}]
@@ -244,7 +251,8 @@
                                                   (reset! selected-index (js/parseInt (.getAttribute (.-target %) "tabIndex"))))
                                 :on-click      #(do
                                                   (reset! typeahead-hidden? true)
-                                                  (save! id result))}
+                                                  (save! id result)
+                                                  (choice-fn result))}
                            [result-fn result]])
                         @selections))]])))
 

--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -208,7 +208,9 @@
                     [type
                      [:input {:type        :text
                               :class       input-class
-                              :value       (get id)
+                              :value       (let [v (get id)]
+                                             (if-not (iterable? v)
+                                               v (first v)))
                               :on-focus    #(when clear-on-focus? (save! id ""))
                               :on-blur     #(when-not @mouse-on-list?
                                               (reset! typeahead-hidden? true)

--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -203,7 +203,11 @@
   (let [typeahead-hidden? (atom true)
         mouse-on-list? (atom false)
         selected-index (atom 0)
-        selections (atom [])]
+        selections (atom [])
+        choose-selected #(do (let [choice (nth @selections @selected-index)]
+                               (save! id choice)
+                               (choice-fn choice))
+                             (reset! typeahead-hidden? true))]
     (render-element attrs doc
                     [type
                      [:input {:type        :text
@@ -230,11 +234,8 @@
                                                      (.preventDefault %)
                                                      (if-not (= @selected-index (- (count @selections) 1))
                                                        (reset! selected-index (+ @selected-index 1))))
-                                                13 (do
-                                                     (let [choice (nth @selections @selected-index)]
-                                                       (save! id choice)
-                                                       (choice-fn choice))
-                                                     (reset! typeahead-hidden? true))
+                                                9  (choose-selected)
+                                                13 (choose-selected)
                                                 27 (do (reset! typeahead-hidden? true)
                                                        (reset! selected-index 0))
                                                 "default"))}]

--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -195,7 +195,7 @@
        body)))
 
 (defmethod init-field :typeahead
-  [[type {:keys [id data-source input-class list-class item-class highlight-class] :as attrs}] {:keys [doc get save!]}]
+  [[type {:keys [id data-source input-class list-class item-class highlight-class result-fn] :as attrs :or {result-fn identity}}] {:keys [doc get save!]}]
   (let [typeahead-hidden? (atom true)
         mouse-on-list? (atom false)
         selected-index (atom 0)
@@ -243,7 +243,9 @@
                                                   (reset! selected-index (js/parseInt (.getAttribute (.-target %) "tabIndex"))))
                                 :on-click      #(do
                                                   (reset! typeahead-hidden? true)
-                                                  (save! id result))} result]) @selections))]])))
+                                                  (save! id result))}
+                           [result-fn result]])
+                        @selections))]])))
 
 
 

--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -229,7 +229,7 @@
                                                        (reset! selected-index 0))
                                                 "default"))}]
 
-                     [:ul {:hidden (or (empty? @selections) @typeahead-hidden?)
+                     [:ul {:style {:display (if (or (empty? @selections) @typeahead-hidden?) :none :block) }
                            :class list-class
                            :on-mouse-enter #(reset! mouse-on-list? true)
                            :on-mouse-leave #(reset! mouse-on-list? false)}

--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -195,7 +195,7 @@
        body)))
 
 (defmethod init-field :typeahead
-  [[type {:keys [id data-source input-class list-class item-class highlight-class result-fn] :as attrs :or {result-fn identity}}] {:keys [doc get save!]}]
+  [[type {:keys [id data-source input-class list-class item-class highlight-class result-fn clear-on-focus?] :as attrs :or {result-fn identity clear-on-focus? true}}] {:keys [doc get save!]}]
   (let [typeahead-hidden? (atom true)
         mouse-on-list? (atom false)
         selected-index (atom 0)
@@ -205,6 +205,7 @@
                      [:input {:type        :text
                               :class       input-class
                               :value       (get id)
+                              :on-focus    #(when clear-on-focus? (save! id ""))
                               :on-blur     #(when-not @mouse-on-list?
                                               (reset! typeahead-hidden? true)
                                               (reset! selected-index 0))


### PR DESCRIPTION
Here are a few changes which I had to make to get the typeahead to work well for me:

* support overriding the per-result DOM in the dropdown (bootstrap 3 css seems to want an `<a>` tag in each element, or nothing is shown)
* support returning a vector e.g. `[name id]` from data-source
* set `style` attr on the dropdown for showing/hiding (bootstrap3 css has a rule `display:none;` on the class `.dropdown` which breaks the typeahead before these changes)
* allow differentiating between a value set by typing in the text input, and a value set by the user choosing an option from the dropdown (optional `choice-fn`)
* TAB key chooses selected item
* focusing the text input, by default, clears it

With these changes, I find it feels very nice and looks great with bootstrap (and I'm using FlatUI as well)

Feedback welcome. Cheers!