### PR TITLE
explicitly evaluate the typeahead result-fn

### DIFF
--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -256,7 +256,7 @@
                                                   (reset! typeahead-hidden? true)
                                                   (save! id result)
                                                   (choice-fn result))}
-                           [result-fn result]])
+                           (result-fn result)])
                         @selections))]])))
 
 


### PR DESCRIPTION
This is a minor fix for the new typeahead functionality. In 0.5.3, when `:result-fn` isn't defined otherwise, react will choke with `Invariant Violation: cljs$core$identity.render(): A valid ReactComponent must be returned. You may have returned undefined, an array or some other invalid object.`