### PR TITLE
Allow BYO id paths

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject reagent-forms "0.5.9"
+(defproject reagent-forms "0.5.10"
   :description "data binding library for Reagent"
   :url "https://github.com/yogthos/reagent-forms"
   :license {:name "Eclipse Public License"

--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -15,8 +15,10 @@
 (def ^:private id->path
   (memoize
     (fn [id]
-      (let [segments (split (subs (str id) 1 ) #"\.")]
-        (map keyword segments)))))
+      (if (sequential? id)
+        id
+        (let [segments (split (subs (str id) 1 ) #"\.")]
+          (map keyword segments))))))
 
 (defn set-doc-value [doc id value events]
   (let [path (id->path id)]


### PR DESCRIPTION
I have a complex data structure with maps within a vector that I cannot access with the current string-based path parsing.  E.g.

    {:foo [{:bar 42 :baz 43} ...]}

This allows you to bring your own path to access like:

    [:foo 0 :bar]

I also considered parsing integer indexes and converting those (:foo.0.bar) but this seemed more flexible.