### PR TITLE
Datepicker boundary issue fix

### DIFF
--- a/src/reagent_forms/datepicker.cljs
+++ b/src/reagent_forms/datepicker.cljs
@@ -125,7 +125,7 @@
     [year (inc month) day]))
 
 
-(defn year-picker [date save! view-selector]
+(defn year-picker [date view-selector]
   (let [start-year (atom (- (first @date) 10))]
     (fn []
       [:table.table-condensed
@@ -143,12 +143,11 @@
                        [:td.year
                         {:on-click #(do
                                      (swap! date assoc-in [0] year)
-                                     (save! {:year (@date 0) :month (inc (@date 1)) :day (@date 2)})
                                      (reset! view-selector :month))
                          :class (when (= year (first @date)) "active")}
                         year]))))])))
 
-(defn month-picker [date save! view-selector]
+(defn month-picker [date view-selector]
   (let [year (atom (first @date))]
     (fn []
       [:table.table-condensed
@@ -173,7 +172,6 @@
                      :on-click
                      #(do
                        (swap! date (fn [[_ _ day]] [@year idx day]))
-                       (save! {:year (@date 0) :month (inc (@date 1)) :day (@date 2)})
                        (reset! view-selector :day))}
                     month-name]))))])))
 
@@ -202,5 +200,5 @@
       [:div {:class (str "datepicker" (when-not @expanded? " dropdown-menu") (if inline " dp-inline" " dp-dropdown"))}
        (condp = @view-selector
          :day   [day-picker date get save! view-selector expanded? auto-close?]
-         :month [month-picker date save! view-selector]
-         :year  [year-picker date save! view-selector])])))
+         :month [month-picker date view-selector]
+         :year  [year-picker date view-selector])])))

--- a/src/reagent_forms/datepicker.cljs
+++ b/src/reagent_forms/datepicker.cljs
@@ -181,12 +181,14 @@
   [:table.table-condensed
    [:thead
     [:tr
-     [:th.prev {:on-click #(swap! date last-date)} "‹"]
+     [:th.prev {:on-click #(let [prev-ym (last-date @date)]
+                             (swap! date assoc 0 (first prev-ym) 1 (second prev-ym)))} "‹"]
      [:th.switch
       {:col-span 5
        :on-click #(reset! view-selector :month)}
       (str (get-in dates [:months (second @date)]) " " (first @date))]
-     [:th.next {:on-click #(swap! date next-date)} "›"]]
+     [:th.next {:on-click #(let [next-ym (next-date @date)]
+                             (swap! date assoc 0 (first next-ym) 1 (second next-ym)))} "›"]]
     (into
       [:tr]
       (for [dow (take 7 (:days-short dates))]

--- a/src/reagent_forms/datepicker.cljs
+++ b/src/reagent_forms/datepicker.cljs
@@ -114,15 +114,15 @@
       (partition 7)
       (map (fn [week] (into [:tr] week))))))
 
-(defn last-date [[year month]]
+(defn last-date [[year month day]]
   (if (pos? month)
-    [year (dec month)]
-    [(dec year) 11]))
+    [year (dec month) day]
+    [(dec year) 11 day]))
 
-(defn next-date [[year month]]
+(defn next-date [[year month day]]
   (if (= month 11)
-    [(inc year) 0]
-    [year (inc month)]))
+    [(inc year) 0 day]
+    [year (inc month) day]))
 
 
 (defn year-picker [date save! view-selector]
@@ -181,14 +181,12 @@
   [:table.table-condensed
    [:thead
     [:tr
-     [:th.prev {:on-click #(let [prev-ym (last-date @date)]
-                             (swap! date assoc 0 (first prev-ym) 1 (second prev-ym)))} "‹"]
+     [:th.prev {:on-click #(swap! date last-date)} "‹"]
      [:th.switch
       {:col-span 5
        :on-click #(reset! view-selector :month)}
       (str (get-in dates [:months (second @date)]) " " (first @date))]
-     [:th.next {:on-click #(let [next-ym (next-date @date)]
-                             (swap! date assoc 0 (first next-ym) 1 (second next-ym)))} "›"]]
+     [:th.next {:on-click #(swap! date next-date)} "›"]]
     (into
       [:tr]
       (for [dow (take 7 (:days-short dates))]


### PR DESCRIPTION
Fix for issue #85.
i. Change last-date and prev-date functions to return a vector of size 3 containing year, month and day and avoid the error: No item 2 in vector of length 2
ii. Update to not save the date on year and month selections to avoid invalid dates e.g. 31/Feb/2016