### PR TITLE
If a date is defined use it instead of the current day

### DIFF
--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -134,7 +134,11 @@
 (defmethod init-field :datepicker
   [[_ {:keys [id date-format inline auto-close?] :as attrs}] {:keys [doc get save!]}]
   (let [fmt (parse-format date-format)
+        selected-date (get id)
         today (js/Date.)
+        year (or (:year selected-date) (.getFullYear today))
+        month (or (dec (:month selected-date)) (.getMonth today))
+        day (or (:day selected-date) (.getDate today))
         expanded? (atom false)]
     (render-element attrs doc
       [:div.datepicker-wrapper
@@ -149,7 +153,7 @@
          [:span.input-group-addon
           {:on-click #(swap! expanded? not)}
           [:i.glyphicon.glyphicon-calendar]]]
-       [datepicker (.getFullYear today) (.getMonth today) (.getDate today) expanded? auto-close? #(get id) #(save! id %) inline]])))
+       [datepicker year month day expanded? auto-close? #(get id) #(save! id %) inline]])))
 
 
 (defmethod init-field :checkbox


### PR DESCRIPTION
as the current value for datepicker fields. Right now if a date is already present the formatted field will show this defined date, the datepicker itself will start with the current calender month, ignoring the defined date.