### PR TITLE
Issue #84: L10n

### DIFF
--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -132,7 +132,7 @@
              attrs)])))
 
 (defmethod init-field :datepicker
-  [[_ {:keys [id date-format inline auto-close?] :as attrs}] {:keys [doc get save!]}]
+  [[_ {:keys [id date-format inline auto-close? lang] :or {lang :en-US} :as attrs}] {:keys [doc get save!]}]
   (let [fmt (parse-format date-format)
         selected-date (get id)
         selected-month (if (pos? (:month selected-date)) (dec (:month selected-date)) (:month selected-date))
@@ -154,7 +154,7 @@
          [:span.input-group-addon
           {:on-click #(swap! expanded? not)}
           [:i.glyphicon.glyphicon-calendar]]]
-       [datepicker year month day expanded? auto-close? #(get id) #(save! id %) inline]])))
+       [datepicker year month day expanded? auto-close? #(get id) #(save! id %) inline lang]])))
 
 
 (defmethod init-field :checkbox

--- a/src/reagent_forms/datepicker.cljs
+++ b/src/reagent_forms/datepicker.cljs
@@ -221,8 +221,9 @@
        [:th.next {:on-click #(swap! date next-date)} "›"]]
       (into
         [:tr]
-        (for [dow local-days-short]
-          [:th.dow {:key dow} dow]))]
+        (map-indexed (fn [i dow]
+                     ^{:key i}  [:th.dow dow])
+                     local-days-short))]
      (into [:tbody]
            (gen-days date get save! expanded? auto-close? local-first-day))]))
 


### PR DESCRIPTION
Datepicker now accepts `:lang` which takes a keyword which maps to built-in
languages like :en-US. 

Currently provides English, Russian, French, Spanish, Portuguese and Finnish mappings. Also, the `:lang` key accepts a language hash-map with correct format.

Language hash-maps must define `:first-day` key which allow choosing arbritrary first day of the week
by index starting from Sunday as 0. Choosing :first-day 1 would render monday as the first day of the week.

Also moved functions related to `gen-days` above it for clarity.

Example usage:
```clojure
{:field :datepicker :id :date :date-format "yyyy/mm/dd" :inline true :lang
 {:days        ["First" "Second" "Third" "Fourth" "Fifth" "Sixth" "Seventh"]
  :days-short  ["1st" "2nd" "3rd" "4th" "5th" "6th" "7th"]
  :months      ["Month-one" "Month-two" "Month-three" "Month-four" "Month-five" "Month-six"
                "Month-seven" "Month-eight" "Month-nine" "Month-ten" "Month-eleven" "Month-twelve"]
  :months-short ["M1" "M2" "M3" "M4" "M5" "M6" "M7" "M8" "M9" "M10" "M12"]
  :first-day 0}}
```
![image](https://cloud.githubusercontent.com/assets/5362346/13196169/a7b769b2-d7cf-11e5-8503-73b7b3a5b94b.png)

```clojure
{:field :datepicker :id :date :date-format "yyyy/mm/dd" :inline true :lang :ru-RU}
```
![image](https://cloud.githubusercontent.com/assets/5362346/13196173/c26f6d90-d7cf-11e5-8218-23f3a39b0194.png)

```clojure
{:field :datepicker :id :date :date-format "yyyy/mm/dd" :inline true}
```
![image](https://cloud.githubusercontent.com/assets/5362346/13196176/d9ff2810-d7cf-11e5-84c5-65bc22468410.png)

```