### PR TITLE
Allow forms to change

### DIFF
--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -391,4 +391,4 @@
                      (if (fn? field) [field] field))
                    node))
                form)]
-    (fn [] form)))
+    form))

--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -198,7 +198,7 @@
                :default-checked (= value (get name))
                :on-change #(save! name value)}
               attrs)]
-       body)))
+      body)))
 
 (defmethod init-field :typeahead
   [[type {:keys [id data-source input-class list-class item-class highlight-class input-placeholder result-fn choice-fn clear-on-focus?]
@@ -249,7 +249,7 @@
                                                        (reset! selected-index 0))
                                                 "default"))}]
 
-                     [:ul {:style {:display (if (or (empty? @selections) @typeahead-hidden?) :none :block) }
+                     [:ul {:style {:display (if (or (empty? @selections) @typeahead-hidden?) :none :block)}
                            :class list-class
                            :on-mouse-enter #(reset! mouse-on-list? true)
                            :on-mouse-leave #(reset! mouse-on-list? false)}


### PR DESCRIPTION
This PR contains the easy fix for #49: It simply changes `bind-fields` to return `form` instead of `(fn [] form)`, which, as a side-effect, also causes the form to be examined by reagent-forms every time the atom changes.

If you want a more complex fix, which retains the behaviour of Reagent Forms to only examine the form once, but still allow it to change (in a non-structural way, e.g. by adding `[:option]`s) later, please tell me, so I can revise this PR.

Fixes: #49
