### PR TITLE
Add 'checked' attribute to checkbox component. Fix gh-97.

### DIFF
--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -85,8 +85,10 @@
 
 (defmethod bind :checkbox
   [{:keys [id]} {:keys [get save!]}]
-  {:default-checked (get id)
-   :on-change #(->> id get not (save! id))})
+  (merge {:default-checked (get id)
+          :on-change       #(->> id get not (save! id))}
+         (when (get id)
+           {:checked "checked"})))
 
 (defmethod bind :default [_ _])
 


### PR DESCRIPTION
This fixes issue #97 

As far as I could see, the 'checked' attribute of the checkbox was not wired to the state atom, so that if you would reset it, the checkbox would not "un-check".

I used merge there because we only want to add "checked" if the checkbox is meant to be checked as the absence of that attribute is the only correct way of saying it shouldn't.

This should now work fine when you clear the form:

```clojure
(defn annotate-pane []
  (let [doc (atom nil)]
    (fn []
      [:div
       [:p (str @doc)]
       [bind-fields
        [:input.form-control {:field :checkbox :id :first-name}]
        doc]
       [:button
        {:on-click #(reset! doc nil)}
        "clear"]])))
```