### PR TITLE
Allow removing the close button on an alert component

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ When an event is supplied then the body of the alert is rendered whenever the ev
 
 When no event is supplied, then the alert is shown whenever the value at the id is not empty and displays the value:
 
+An optional `:closeable? true/false` can be provided to control if a close button should be rendered (defaults to true).
+
 ```clojure
 (def doc (atom {}))
 
@@ -247,6 +249,8 @@ The container can be used to set the visibility of multiple elements.
  [:input {:field :text :id :first-name}]
  [:input {:field :text :id :last-name}]]
 ```
+
+`:valid?` key accepts a function which takes the current state of the document as a the sole argument. This function returns a class to be concatenated to the class list of the element.
 
 ### Setting component visibility
 

--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -173,18 +173,19 @@
        placeholder)]))
 
 (defmethod init-field :alert
-  [[type {:keys [id event touch-event] :as attrs} & body] {:keys [doc get save!] :as opts}]
+  [[type {:keys [id event touch-event closeable?] :or {closeable? true} :as attrs} & body] {:keys [doc get save!] :as opts}]
   (render-element attrs doc
     (if event
       (when (event (get id))
         (into [type (dissoc attrs event)] body))
       (if-let [message (not-empty (get id))]
         [type attrs
-         [:button.close
-           {:type                      "button"
-            :aria-hidden               true
-            (or touch-event :on-click) #(save! id nil)}
-           "X"]
+         (when closeable?
+           [:button.close
+            {:type                      "button"
+             :aria-hidden               true
+             (or touch-event :on-click) #(save! id nil)}
+            "X"])
          message]))))
 
 (defmethod init-field :radio


### PR DESCRIPTION
With optional key :closeable? (defaults to true) you can remove the
close button element. This allows having :field :alert on elements on
which a close button is undesireable.