### PR TITLE
Set value to an empty string in case the date is nil

### DIFF
--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -169,7 +169,9 @@
             :on-click #(do
                          (.preventDefault %)
                          (swap! expanded? not))
-            :value (when-let [date (get id)] (format-date date fmt))}
+            :value (if-let [date (get id)]
+                     (format-date date fmt)
+                     "")}
            (clean-attrs attrs))]
          [:span.input-group-addon
           {:on-click #(do


### PR DESCRIPTION
This change in React https://github.com/facebook/react/issues/5013
causes the warning message if the value of an input is null.