### PR TITLE
When choosing a candidate with ret key preventDefault

### DIFF
--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -270,7 +270,9 @@
                                                        (save! id (value-of %))
                                                        (swap! selected-index inc)))
                                                 9  (choose-selected)
-                                                13 (choose-selected)
+                                                13 (do
+                                                     (.preventDefault %)
+                                                     (choose-selected))
                                                 27 (do (reset! typeahead-hidden? true)
                                                        (reset! selected-index 0))
                                                 "default"))}]


### PR DESCRIPTION
If not when a typeahead is for example used inside a form, then choosing a
candidate by ret key can result in a submit.