### PR TITLE
preventDefault on a click on a candidate in typeahead

### DIFF
--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -288,6 +288,7 @@
                                 :on-mouse-over #(do
                                                   (reset! selected-index (js/parseInt (.getAttribute (.-target %) "tabIndex"))))
                                 :on-click      #(do
+                                                  (.preventDefault %)
                                                   (reset! typeahead-hidden? true)
                                                   (save! id result)
                                                   (choice-fn result))}


### PR DESCRIPTION
This fixes the case when option `clear-on-focus` is set to true. Without
it clicking on a candidate clears the value in the input.