### PR TITLE
Typeahead new features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ pom.xml.asc
 /resources/public/js/
 /forms-example/resources/public/js/
 /forms-example/target/
+*.iml
+.idea

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ The library uses a Reagent atom as the document store. The components are bound 
 
 The `:id` can be a keyword, e.g: `{:id :foo}`, or a keywordized path `{:id :foo.bar}` that will map to `{:foo {:bar "value"}}`. Alternatively, you can specify a vector path explicitly `[:foo 0 :bar]`.
 
+By default the component value is that of the document field, however all components support an `:in-fn` and `:out-fn` function attributes.
+`:in-fn` accepts the current document value and returns what is to be displayed in the component. `:out-fn` accepts the component value
+and returns what is to be stored in the document.
+
 The following types of fields are supported out of the box:
 
 #### :input
@@ -51,9 +55,10 @@ The typeahead field uses a `:data-source` key bound to a function that takes the
 
 The typeahead field supports both mouse and keyboard selection.
 
-##### Different label and value
+##### Different display and value
 
-You can make the input's value be different then the value stored in the document. You need to specify `in-fn`, `out-fn` and `result-fn`. The `:data-source` needs to return a vector `[name id]`.
+You can make the input's displayed value be different to the value stored in the document. You need to specify `:out-fn`, a `:result-fn` and
+optionally `:in-fn`. The `:data-source` needs to return a vector `[display-value stored-value]`.
 
 ```clojure
 (defn people-source [people]
@@ -63,17 +68,31 @@ You can make the input's value be different then the value stored in the documen
                       (.toLowerCase)
                       (.indexOf text)
                       (> -1)))
-         (mapv #(vector (:name %) (:id %))))))
+         (mapv #(vector (:name %) (:num %))))))
 
-[:div {:field :typeahead,
+[:div {:field :typeahead
        :data-source (people-source people)
-       :in-fn (fn [id]
-                [(:name (first (filter #(= id (:id %)) people))) id])
-       :out-fn (fn [[name id]] id)
-       :result-fn (fn [[name id]] name)
-       :id :author.id}]]]
+       :in-fn (fn [num]
+                [(:name (first (filter #(= num (:num %)) people))) num])
+       :out-fn (fn [[name num]] num)
+       :result-fn (fn [[name num]] name)
+       :id :author.num}]]]
 ```
 
+##### Pop down the list
+
+If `:data-source` responds with the full option list when passed the keyword `:all` then the down-arrow key will show the list.
+
+##### Selection list from Ajax
+
+The `:selections` attribute can be specified to pass an atom used to hold the selections. This gives the option to fetch the
+list using typeahead text - if an ajax response handler sets the atom the list will pop down.
+
+##### Display selection on pop-down
+
+If supplied, the `:get-index` function will ensure the selected item is highlighted when the list is popped down.
+
+A full example is available in the source code for the demonstration page.
 
 #### :checkbox
 

--- a/dev/public/index.html
+++ b/dev/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+    <link rel="stylesheet" href="../../resources/reagent-forms.css">
 </head>
 <body>
 <div id="app">

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject reagent-forms "0.5.30"
+(defproject reagent-forms "0.5.31-SNAPSHOT"
   :description "data binding library for Reagent"
   :url "https://github.com/yogthos/reagent-forms"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                                :figwheel     {:on-jsload "reagent-forms.page/mount-root"}
                                :compiler
                                              {:main          "reagent-forms.app"
-                                              :asset-path    "/js/out"
+                                              :asset-path    "js/out"
                                               :output-to     "dev/public/js/app.js"
                                               :output-dir    "dev/public/js/out"
                                               :source-map    true


### PR DESCRIPTION
Suggested additions to typeahead:

- If the `:data-source` function returns a single element then this is automatically selected. This is not configurable as currently implemented, it seemed a subtle enough change not to upset anyone, but could be optional of course

- If the typeahead list is long enough to scroll, the list doesn't autoscroll with the keyboard. Added code to fix this.

- I wanted the full list to become visible without actually typing anything. I added code so down-arrow will display the list, which it does by calling `:data-source` passing the keyword `:all`. This isn't a breaking change, in that an empty list would be returned anyway if the client doesn't implement this.
This mod leaves the way open for adding a dropdown button, should someone want that.

- If the `:get-index` function is supplied, when the list is popped down as above the current item is shown selected.

- May be the selections list is the result of an ajax call using the text the user is typing and invoked from `:data-source`. In this case the ajax result handler would set an atom, so I added an option for this to be user-supplied via `:selections`. 

See source code for the demo page for a full example.