### PR TITLE
:disabled should support functions

### DIFF
--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -173,7 +173,7 @@
              (clean-attrs attrs))])))
 
 (defmethod init-field :datepicker
-  [[_ {:keys [id date-format inline auto-close? lang] :or {lang :en-US} :as attrs}] {:keys [doc get save!]}]
+  [[_ {:keys [id date-format inline auto-close? disabled lang] :or {lang :en-US} :as attrs}] {:keys [doc get save!]}]
   (let [fmt (parse-format date-format)
         selected-date (get id)
         selected-month (if (pos? (:month selected-date)) (dec (:month selected-date)) (:month selected-date))
@@ -197,9 +197,10 @@
                      "")}
            (clean-attrs attrs))]
          [:span.input-group-addon
-          {:on-click #(do
+          {:on-click #(let [disabled? (if (fn? disabled) (disabled) disabled)]
                         (.preventDefault %)
-                        (swap! expanded? not))}
+                        (when-not disabled?
+                          (swap! expanded? not)))}
           [:i.glyphicon.glyphicon-calendar]]]
        [datepicker year month day expanded? auto-close? #(get id) #(save! id %) inline lang]])))
 

--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -268,6 +268,7 @@
     (render-element attrs doc
                     [type
                      [:input {:type        :text
+                              :disabled    (:disabled attrs)
                               :placeholder input-placeholder
                               :class       input-class
                               :value       (let [v (get id)]

--- a/src/reagent_forms/macros.clj
+++ b/src/reagent_forms/macros.clj
@@ -6,7 +6,8 @@
                            :typeahead [1 1 :disabled]
                            :datepicker [1 1 1 :disabled]
                            [1 :disabled])
-           body# (if (:disabled ~attrs)
+           body# (if (and (:disabled ~attrs)
+                          (get-in ~@body disabled-path#))
                    (update-in ~@body disabled-path# #(if (fn? %) (%) %))
                    ~@body)]
        (if-let [visible# (:visible? ~attrs)]

--- a/src/reagent_forms/macros.clj
+++ b/src/reagent_forms/macros.clj
@@ -2,7 +2,10 @@
 
 (defmacro render-element [attrs doc & body]
   `(fn []
-     (if-let [visible# (:visible? ~attrs)]
-       (when (visible# (deref ~doc))
-         ~@body)
-       ~@body)))
+     (let [body# (if (:disabled ~attrs)
+                   (update-in ~@body [1 :disabled] #(if (fn? %) (%) %))
+                   ~@body)]
+       (if-let [visible# (:visible? ~attrs)]
+         (when (visible# (deref ~doc))
+           body#)
+         body#))))

--- a/src/reagent_forms/macros.clj
+++ b/src/reagent_forms/macros.clj
@@ -2,8 +2,11 @@
 
 (defmacro render-element [attrs doc & body]
   `(fn []
-     (let [body# (if (:disabled ~attrs)
-                   (update-in ~@body [1 :disabled] #(if (fn? %) (%) %))
+     (let [disabled-path# (if (= :typeahead (:field ~attrs))
+                           [1 1 :disabled]
+                           [1 :disabled])
+           body# (if (:disabled ~attrs)
+                   (update-in ~@body disabled-path# #(if (fn? %) (%) %))
                    ~@body)]
        (if-let [visible# (:visible? ~attrs)]
          (when (visible# (deref ~doc))

--- a/src/reagent_forms/macros.clj
+++ b/src/reagent_forms/macros.clj
@@ -2,8 +2,9 @@
 
 (defmacro render-element [attrs doc & body]
   `(fn []
-     (let [disabled-path# (if (= :typeahead (:field ~attrs))
-                           [1 1 :disabled]
+     (let [disabled-path# (case (:field ~attrs)
+                           :typeahead [1 1 :disabled]
+                           :datepicker [1 1 1 :disabled]
                            [1 :disabled])
            body# (if (:disabled ~attrs)
                    (update-in ~@body disabled-path# #(if (fn? %) (%) %))


### PR DESCRIPTION
`:disabled` should support boolean value or a function (similarly to `:visible?` - see #59)

This PR also adds (previously missing) support for `:disabled` in either of the two forms to the following components:
- Typeahead
- Datepicker

Still unsupported elements:
- `[:option]`
-  `[:button]`s inside `btn-group` 

I'm not sure how to handle those yet. The structure is more complicated - I could use clojure.walk but I'm trying to think of a simpler solution without additional dependency. I'll revisit when I have time again.