### PR TITLE
Support for :disabled on select-groups/lists

### DIFF
--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -366,7 +366,8 @@
       (let [disabled? (if (fn? disabled) (disabled) disabled)]
         [type
          (merge {:class (if (get @selections key) "active")
-                 (or touch-event :on-click) handle-click!}
+                 (or touch-event :on-click)
+                 (when-not disabled? handle-click!)}
                 (clean-attrs attrs)
                 {:disabled disabled?})
          body]))))

--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -2,7 +2,7 @@
   (:require-macros [reagent-forms.macros :refer [render-element]])
   (:require
    [clojure.walk :refer [postwalk]]
-   [clojure.string :refer [split trim]]
+   [clojure.string :refer [split trim join blank?]]
    [goog.string :as gstring]
    [goog.string.format]
    [reagent.core :refer [atom cursor]]
@@ -366,12 +366,10 @@
             active? (get @selections key)
             button-or-input? (let [t (subs (name type) 0 5)]
                                (or (= t "butto") (= t "input")))
-            class (str (when active?
-                         "active")
-                       (when (and active? disabled? (not button-or-input?))
-                         " ")
-                       (when (and disabled? (not button-or-input?))
-                         "disabled"))]
+            class (->> [(when active? "active")
+                        (when (and disabled? (not button-or-input?)) "disabled")]
+                       (remove blank?)
+                       (join " "))]
         [type
          (dissoc
            (merge {:class class

--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -173,7 +173,7 @@
              (clean-attrs attrs))])))
 
 (defmethod init-field :datepicker
-  [[_ {:keys [id date-format inline auto-close? lang] :or {lang :en-US} :as attrs}] {:keys [doc get save!]}]
+  [[_ {:keys [id date-format inline auto-close? disabled lang] :or {lang :en-US} :as attrs}] {:keys [doc get save!]}]
   (let [fmt (parse-format date-format)
         selected-date (get id)
         selected-month (if (pos? (:month selected-date)) (dec (:month selected-date)) (:month selected-date))
@@ -197,9 +197,10 @@
                      "")}
            (clean-attrs attrs))]
          [:span.input-group-addon
-          {:on-click #(do
+          {:on-click #(let [disabled? (if (fn? disabled) (disabled) disabled)]
                         (.preventDefault %)
-                        (swap! expanded? not))}
+                        (when-not disabled?
+                          (swap! expanded? not)))}
           [:i.glyphicon.glyphicon-calendar]]]
        [datepicker year month day expanded? auto-close? #(get id) #(save! id %) inline lang]])))
 

--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -350,7 +350,9 @@
                   :on-change #(save! id (-> % .-target .-files))}
                  (clean-attrs attrs))]))
 
-(defn- group-item [[type {:keys [key touch-event] :as attrs} & body] {:keys [save! multi-select]} selections field id]
+(defn- group-item
+  [[type {:keys [key touch-event disabled] :as attrs} & body]
+   {:keys [save! multi-select]} selections field id]
   (letfn [(handle-click! []
            (if multi-select
              (do
@@ -361,12 +363,15 @@
                (save! id (when (get @selections key) key)))))]
 
     (fn []
-      [type (merge {:class (if (get @selections key) "active")
-                    (or touch-event :on-click) handle-click!}
-                   (clean-attrs attrs))
-       body])))
+      (let [disabled? (if (fn? disabled) (disabled) disabled)]
+        [type
+         (merge {:class (if (get @selections key) "active")
+                 (or touch-event :on-click) handle-click!}
+                (clean-attrs attrs)
+                {:disabled disabled?})
+         body]))))
 
-(defn- mk-selections [id selectors {:keys [get multi-select]}]
+(defn- mk-selections [id selectors {:keys [get multi-select] :as ks}]
   (let [value (get id)]
     (reduce
      (fn [m [_ {:keys [key]}]]

--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -268,6 +268,7 @@
     (render-element attrs doc
                     [type
                      [:input {:type        :text
+                              :disabled    (:disabled attrs)
                               :placeholder input-placeholder
                               :class       input-class
                               :value       (let [v (get id)]

--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -361,22 +361,25 @@
              (let [value (get @selections key)]
                (reset! selections {key (not value)})
                (save! id (when (get @selections key) key)))))]
-
     (fn []
       (let [disabled? (if (fn? disabled) (disabled) disabled)
             active? (get @selections key)
-            button-or-input? (or (= type :button) (= type :input))]
+            button-or-input? (let [t (subs (name type) 0 5)]
+                               (or (= t "butto") (= t "input")))
+            class (str (when active?
+                         "active")
+                       (when (and active? disabled? (not button-or-input?))
+                         " ")
+                       (when (and disabled? (not button-or-input?))
+                         "disabled"))]
         [type
-         (merge {:class (str (when active?
-                               "active")
-                             (when (and active? disabled? (not button-or-input?))
-                               " ")
-                             (when (and disabled? (not button-or-input?))
-                               "disabled"))
-                 (or touch-event :on-click)
-                 (when-not disabled? handle-click!)}
-                (clean-attrs attrs)
-                {:disabled disabled?})
+         (dissoc
+           (merge {:class class
+                   (or touch-event :on-click)
+                   (when-not disabled? handle-click!)}
+                  (clean-attrs attrs)
+                  {:disabled disabled?})
+           (when-not button-or-input? :disabled))
          body]))))
 
 (defn- mk-selections [id selectors {:keys [get multi-select] :as ks}]

--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -363,9 +363,16 @@
                (save! id (when (get @selections key) key)))))]
 
     (fn []
-      (let [disabled? (if (fn? disabled) (disabled) disabled)]
+      (let [disabled? (if (fn? disabled) (disabled) disabled)
+            active? (get @selections key)
+            button-or-input? (or (= type :button) (= type :input))]
         [type
-         (merge {:class (if (get @selections key) "active")
+         (merge {:class (str (when active?
+                               "active")
+                             (when (and active? disabled? (not button-or-input?))
+                               " ")
+                             (when (and disabled? (not button-or-input?))
+                               "disabled"))
                  (or touch-event :on-click)
                  (when-not disabled? handle-click!)}
                 (clean-attrs attrs)

--- a/src/reagent_forms/macros.clj
+++ b/src/reagent_forms/macros.clj
@@ -6,7 +6,8 @@
                            :typeahead [1 1 :disabled]
                            :datepicker [1 1 1 :disabled]
                            [1 :disabled])
-           body# (if (:disabled ~attrs)
+           body# (if (and (:disabled ~attrs)
+                          (get-in ~@body disabled-path#))
                    (update-in ~@body disabled-path# #(if (fn? %) (%) %))
                    ~@body)]
        (if-let [visible# (:visible? ~attrs)]

--- a/src/reagent_forms/macros.clj
+++ b/src/reagent_forms/macros.clj
@@ -2,7 +2,10 @@
 
 (defmacro render-element [attrs doc & body]
   `(fn []
-     (if-let [visible# (:visible? ~attrs)]
-       (when (visible# (deref ~doc))
-         ~@body)
-       ~@body)))
+     (let [body# (if (:disabled ~attrs)
+                   (update-in ~@body [1 :disabled] #(if (fn? %) (%) %))
+                   ~@body)]
+       (if-let [visible# (:visible? ~attrs)]
+         (when (visible# (deref ~doc))
+           body#)
+         body#))))

--- a/src/reagent_forms/macros.clj
+++ b/src/reagent_forms/macros.clj
@@ -2,8 +2,11 @@
 
 (defmacro render-element [attrs doc & body]
   `(fn []
-     (let [body# (if (:disabled ~attrs)
-                   (update-in ~@body [1 :disabled] #(if (fn? %) (%) %))
+     (let [disabled-path# (if (= :typeahead (:field ~attrs))
+                           [1 1 :disabled]
+                           [1 :disabled])
+           body# (if (:disabled ~attrs)
+                   (update-in ~@body disabled-path# #(if (fn? %) (%) %))
                    ~@body)]
        (if-let [visible# (:visible? ~attrs)]
          (when (visible# (deref ~doc))

--- a/src/reagent_forms/macros.clj
+++ b/src/reagent_forms/macros.clj
@@ -2,8 +2,9 @@
 
 (defmacro render-element [attrs doc & body]
   `(fn []
-     (let [disabled-path# (if (= :typeahead (:field ~attrs))
-                           [1 1 :disabled]
+     (let [disabled-path# (case (:field ~attrs)
+                           :typeahead [1 1 :disabled]
+                           :datepicker [1 1 1 :disabled]
                            [1 :disabled])
            body# (if (:disabled ~attrs)
                    (update-in ~@body disabled-path# #(if (fn? %) (%) %))


### PR DESCRIPTION
Following up on #125 this PR adds support for `:disabled` on inner `:*-select` or `:list` fields.

I ended up using `clojure.walk` after all as this is the only way I can think of to traverse the unknown structures (we can't assume users won't add additional markup around inner buttons/divs/lis inside `.button-group`). I'm open to suggestions.

