### PR TITLE
Add a version of `bind-fields` accepting a map of `get/update!/save!` functions

### DIFF
--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -510,7 +510,7 @@
 
 (defmethod bind-fields PersistentArrayMap
   [form doc]
-  (let [form (make-form form doc false)]
+  (let [form (make-form form (assoc doc :doc (:get doc)) false)]
     (fn [] form)))
 
 (defmethod bind-fields :default

--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -493,22 +493,31 @@
        (map? (second node))
        (contains? (second node) :field)))
 
-(defn bind-fields
-  "creates data bindings between the form fields and the supplied atom
-   form - the form template with the fields
-   doc - the document that the fields will be bound to
-   events - any events that should be triggered when the document state changes"
+(defn make-form
+  [form opts wrap-fns?]
+  (postwalk
+    (fn [node]
+      (if (field? node)
+        (let [opts (if wrap-fns? (wrap-fns opts node) opts)
+              field (init-field node opts)]
+          (if (fn? field) [field] field))
+        node))
+    form))
+
+(defmulti bind-fields
+  (fn [_ doc & _]
+    (type doc)))
+
+(defmethod bind-fields PersistentArrayMap
+  [form doc]
+  (let [form (make-form form doc false)]
+    (fn [] form)))
+
+(defmethod bind-fields :default
   [form doc & events]
   (let [opts {:doc doc
               :get #(deref (cursor-for-id doc %))
               :save! (mk-save-fn doc events)
               :update! (mk-update-fn doc events)}
-        form (postwalk
-               (fn [node]
-                 (if (field? node)
-                   (let [opts (wrap-fns opts node)
-                         field (init-field node opts)]
-                     (if (fn? field) [field] field))
-                   node))
-               form)]
+        form (make-form form opts true)]
     (fn [] form)))

--- a/src/reagent_forms/macros.clj
+++ b/src/reagent_forms/macros.clj
@@ -14,6 +14,8 @@
                        c#))
                    ~@body)]
        (if-let [visible# (:visible? ~attrs)]
-         (when (visible# (deref ~doc))
-           body#)
+         (let [pred# (if (fn? visible#)
+                       (visible# (deref ~doc))
+                       (~doc visible#))]
+          (when pred# body#))
          body#))))

--- a/test/reagent_forms/core_test.cljs
+++ b/test/reagent_forms/core_test.cljs
@@ -344,4 +344,22 @@
                      [:input {:field :numeric}]
                      [:input {:field :range}]]
           result ((core/bind-fields component nil))]
-      (is (= result component)))))
+      (is (= result component))))
+
+  (testing ":doc is associated with :get when map is passed."
+    (with-redefs [core/init-field
+                  (fn [node opts]
+                    (is (= opts
+                           {:doc :get
+                            :get :get
+                            :save! :save!
+                            :udpate! :update!}))
+                    node)]
+      (let [component [:div
+                       [:input {:field :text :id :a}]
+                       [:input {:field :numeric}]
+                       [:input {:field :range}]]
+            result ((core/bind-fields component {:get :get
+                                                 :save! :save!
+                                                 :udpate! :update!}))]
+        (is (= result component))))))


### PR DESCRIPTION
This PR allows a user to pass a map of `get/save!/update!` functions to override the default `bind-fields` behavior for those events (as per #127). In particular, this will allow the user to make `reagent-forms` compatible with libraries like `re-frame`. For example:

```clojure
[bind-fields
 [:input {:field :text :id :xyz}]
 {:get (fn [id] (deref (re-frame/subscribe [id])))
  :save! (fn [id v] (re-frame/dispatch [id v]))
  :update! (fn [id v] (re-frame/dispatch [id v]))}]
```

In this version, `bind-fields` no longer supports the `& events` part since it seems redundant - the functions would have the same signature as the functions in above map.

In addition, `visible?` will now support passing an id to be used by the specified `:get` function.
In above example, an input like this:

```clojure
[:input {:field :text :visible? :some-subscription}]
````

would call `(deref (re-frame/subscribe [:some-subscription])` and the value returned would be used as a predicate for input's visibility. 