### PR TITLE
Wrap-fns for re-frame mode

### DIFF
--- a/src/reagent_forms/core.cljs
+++ b/src/reagent_forms/core.cljs
@@ -496,11 +496,11 @@
        (contains? (second node) :field)))
 
 (defn make-form
-  [form opts wrap-fns?]
+  [form opts]
   (postwalk
     (fn [node]
       (if (field? node)
-        (let [opts (if wrap-fns? (wrap-fns opts node) opts)
+        (let [opts (wrap-fns opts node)
               field (init-field node opts)]
           (if (fn? field) [field] field))
         node))
@@ -517,7 +517,7 @@
 
 (defmethod bind-fields PersistentArrayMap
   [form doc]
-  (let [form (make-form form (assoc doc :doc (:get doc)) false)]
+  (let [form (make-form form (assoc doc :doc (:get doc)))]
     (fn [] form)))
 
 (defmethod bind-fields :default
@@ -526,5 +526,5 @@
               :get #(deref (cursor-for-id doc %))
               :save! (mk-save-fn doc events)
               :update! (mk-update-fn doc events)}
-        form (make-form form opts true)]
+        form (make-form form opts)]
     (fn [] form)))

--- a/test/reagent_forms/core_test.cljs
+++ b/test/reagent_forms/core_test.cljs
@@ -353,7 +353,7 @@
                            {:doc :get
                             :get :get
                             :save! :save!
-                            :udpate! :update!}))
+                            :update! :update!}))
                     node)]
       (let [component [:div
                        [:input {:field :text :id :a}]
@@ -361,5 +361,5 @@
                        [:input {:field :range}]]
             result ((core/bind-fields component {:get :get
                                                  :save! :save!
-                                                 :udpate! :update!}))]
+                                                 :update! :update!}))]
         (is (= result component))))))


### PR DESCRIPTION
As per discussion in #138, `wrap-fns` is required for `save-fn`, `in-fn` and similar to work.